### PR TITLE
HTML markup in the img alt attribute

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -23,7 +23,7 @@
 				<div class="pure-g-r">
 					<div class="pure-u-1-4">
 						{{#if author.image}}
-							<img class="sheet-author-image" src="{{author.image}}" alt="{{author}}" />
+							<img class="sheet-author-image" src="{{author.image}}" alt="{{author.name}}" />
 						{{/if}}
 					</div>
 


### PR DESCRIPTION
I notice that after upgrading to Ghost 0.5.0.
There was HTML markup inserted by `{{author}}` in the `<img>` `alt` attribute.
So I replaced it with `{{author.name}}`.
