### PR TITLE
Load the font with HTTPS when needed

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -13,7 +13,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 		<link rel="stylesheet" href="{{asset "fonts/font-awesome/css/font-awesome.min.css"}}">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+		<link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
 
 		<link rel="stylesheet" href="{{asset "css/pure.min.css"}}">
 		<link rel="stylesheet" href="{{asset "css/screen.css"}}">


### PR DESCRIPTION
When the blog is served via HTTPS, the browser refuse to load the font because it comes from an entrusted source.

I just remove the `http:` prefix from the `href`, so that the font is loaded via HTTP or HTTPS.
